### PR TITLE
Add option to BatchImport to skip schema load

### DIFF
--- a/samples/date-helper.groovy
+++ b/samples/date-helper.groovy
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ *   Copyright 2017 IBM Corp. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *******************************************************************************/
+ 
 def createDate(year, month, day) {
         c = Calendar.getInstance()
         c.clear()

--- a/src/com/ibm/janusgraph/utils/importer/BatchImport.java
+++ b/src/com/ibm/janusgraph/utils/importer/BatchImport.java
@@ -26,12 +26,13 @@ public class BatchImport {
 
         if (null == args || args.length < 4) {
             System.err.println(
-                    "Usage: BatchImport <janusgraph-config-file> <data-files-directory> <schema.json> <data-mapping.json>");
+                    "Usage: BatchImport <janusgraph-config-file> <data-files-directory> <schema.json> <data-mapping.json> [skipSchema]");
             System.exit(1);
         }
 
         JanusGraph graph = JanusGraphFactory.open(args[0]);
-        new SchemaLoader().loadSchema(graph, args[2]);
+        if (!(args.length > 4 && args[4].equals("skipSchema")))
+            new SchemaLoader().loadSchema(graph, args[2]);
         new DataLoader(graph).loadVertex(args[1], args[3]);
         new DataLoader(graph).loadEdges(args[1], args[3]);
         graph.close();


### PR DESCRIPTION
Add an option to BatchImport to skip schema loading so
it can be used just to import data from csv files. Also
add license header to sample groovy.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>