### PR TITLE
User groovyc to compile SchemaImporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ Use maven to build this project:
 
 ### JanusGraphSchemaImporter
 
-This utility read GraphSON schema document and write to JanusGraph.
-Please see the sample GraphSON schema document under `samples` directory.
-
-Usage:
+This utility read GraphSON schema document and write to JanusGraph. You can
+run JanusGraphSchemaImporter in two ways:
+- Using groovy script in JanusGraph gremlin console:  
+  After you build the project. You can see the groovy script under `target/groovy` and
+  named `JanusGraphSchemaImporter.groovy`  
+  Usage:  
 ```
 gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cassandra-embedded-es.properties')
 ==>standardjanusgraph[embeddedcassandra:[127.0.0.1]]
@@ -33,7 +35,10 @@ gremlin> :load JanusGraphSchemaImporter.groovy
 ==>true
 ==>true
 gremlin> writeGraphSONSchema(graph, 'schema.json')
-```
+```  
+  You can find the sample GraphSON schema document under `samples` directory.
+- Using `run.sh` with `loadsch` option to load the schema via JanusGraph Java API.  
+  Usage: `./run.sh loadsch <janusgraph-config-file> <schema-file>`
 
 #### How to load the groovy script in gremlin console
 Use the following command to load the utility groovy script into gremlin console:

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,67 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>addSources</goal>
+              <goal>generateStubs</goal>
+              <goal>compile</goal>
+              <goal>removeStubs</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <sources>
+            <source>
+              <directory>${project.basedir}/src/com/ibm/janusgraph/utils</directory>
+              <includes>
+                <include>**/*.groovy</include>
+              </includes>
+            </source>
+          </sources>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.google.code.maven-replacer-plugin</groupId>
+        <artifactId>replacer</artifactId>
+        <version>1.5.2</version>
+        <executions>
+          <execution>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>replace</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <ignoreMissingFile>true</ignoreMissingFile>
+          <file>src/com/ibm/janusgraph/utils/schema/JanusGraphSchemaImporter.groovy</file>
+          <outputFile>${project.build.directory}/groovy/JanusGraphSchemaImporter.groovy</outputFile>
+          <regex>false</regex>
+          <token>package com.ibm.janusgraph.utils.schema</token>
+          <value></value>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+          <configuration>
+          <filesets>
+            <fileset>
+                <directory>${project.build.directory}/groovy</directory>
+              <includes>
+                <include>*.groovy</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/src/com/ibm/janusgraph/utils/importer/schema/SchemaLoader.java
+++ b/src/com/ibm/janusgraph/utils/importer/schema/SchemaLoader.java
@@ -15,13 +15,9 @@
  *******************************************************************************/
 package com.ibm.janusgraph.utils.importer.schema;
 
-import java.io.File;
-import java.lang.reflect.Method;
-
+import com.ibm.janusgraph.utils.schema.JanusGraphSONSchema;
 import org.janusgraph.core.JanusGraph;
 import org.janusgraph.core.JanusGraphFactory;
-
-import groovy.lang.GroovyClassLoader;
 
 public class SchemaLoader {
 
@@ -29,19 +25,8 @@ public class SchemaLoader {
     }
 
     public void loadSchema(JanusGraph g, String schemaFile) throws Exception {
-        GroovyClassLoader gcl = new GroovyClassLoader();
-        Class<?> groovyclass = gcl.parseClass(new File("src/JanusGraphModelImporter.groovy"));
-
-        Object scriptInstance = groovyclass.newInstance();
-
-        Class<?>[] args = new Class[2];
-        args[0] = JanusGraph.class;
-        args[1] = String.class;
-
-        Method m = scriptInstance.getClass().getMethod("writeGraphSONModel", args);
-        m.invoke(scriptInstance, g, schemaFile);
-        gcl.close();
-
+        JanusGraphSONSchema importer = new JanusGraphSONSchema(g);
+        importer.readFile(schemaFile);
     }
 
     public static void main(String[] args) {

--- a/src/com/ibm/janusgraph/utils/schema/JanusGraphSchemaImporter.groovy
+++ b/src/com/ibm/janusgraph/utils/schema/JanusGraphSchemaImporter.groovy
@@ -13,6 +13,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  *******************************************************************************/
+package com.ibm.janusgraph.utils.schema
+
 import org.apache.tinkerpop.gremlin.process.traversal.Order
 import org.apache.tinkerpop.gremlin.structure.Direction
 import org.apache.tinkerpop.gremlin.structure.Edge

--- a/test/SchemaImporterTest.groovy
+++ b/test/SchemaImporterTest.groovy
@@ -14,7 +14,7 @@
  *    limitations under the License.
  *******************************************************************************/
 
-:load files/src/JanusGraphSchemaImporter.groovy
+:load files/groovy/JanusGraphSchemaImporter.groovy
 
 graph = JanusGraphFactory.open('conf/janusgraph-berkeleyje.properties')
 writeGraphSONSchema(graph, 'files/samples/schema.json')

--- a/test/test.sh
+++ b/test/test.sh
@@ -19,13 +19,14 @@ set -e
 
 find . -name '*.sh' -exec shellcheck {} +
 
+echo "verify Data generator"
+mvn package \
+    && ./run.sh gencsv csv-conf/tiny_config.json /tmp
+
 echo "verify JanusGraphSchemaImporter"
-mkdir files && cp -r samples files/ && cp -r test files/ && cp -r src files/ \
+mkdir files && cp -r samples files/ && cp -r test files/ && cp -r target/groovy/ files/ \
     && docker run --rm -ti -v "$(pwd)"/files:/home/janusgraph/janusgraph/files \
         yihongwang/janusgraph-console bin/gremlin.sh -e files/test/SchemaImporterTest.groovy \
     && rm -rf files
 
-echo "verify Data generator"
 
-mvn package \
-    && ./run.sh gencsv csv-conf/tiny_config.json /tmp


### PR DESCRIPTION
Use groovyc to compile SchemaImporter and use the compiled code
in importer instead of groovy script. In this way, everyting is packed
into the jar file.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>