### PR TITLE
Replace README.md with journey stile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,251 +1,132 @@
-# Utility Tools for JanusGraph [![Build Status](https://travis-ci.org/IBM/janusgraph-utils.svg?branch=master)](https://travis-ci.org/IBM/janusgraph-utils)
+# Develop a scalable graph database app using JanusGraph [![Build Status](https://travis-ci.org/IBM/janusgraph-utils.svg?branch=master)](https://travis-ci.org/IBM/janusgraph-utils)
 
-Provide several utility tools that could be used for Janusgraph, including:
+This journey contains sample data and code for running a Twitter-like application in JanusGraph. The utility code illustrates how to use OLTP APIs to define schema, ingest data, and query graph. Developers can use or modify the code to build and operate their custom graph applications, or create similar java and groovy files to interact with JanusGraph.
 
-- [JanusGraphSchemaImporter](#janusgraphschemaimporter): a groovy script that imports GraphSON schema document into JanusGraph
-- [Synthetic data generator](#synethic-data-generator): a tools for generating synthetic data in CVS format
-- [Data importor](#import-csv-file-to-janusgraph): a tool to import data into JanusGraph in CVS format
+When the reader has completed this journey, they will understand how to:
+* Generate a synthetic graph dataset
+* Load a graph schema from json
+* Import graph data in csv files into JanusGraph database
+* Query and update graph data using Console and REST API
+* Setup and configure a scalable JanusGraph system
 
-## Download and Build
+![](doc/source/images/architecture.png)
 
-Download the files from git repo and get into the directory:
+## Flow
+Prerequisites:
+Install and configure JanusGraph, Cassandra, ElasticSearch, janusgraph-utils
+
+1. The user generates Twitter sample schema and data using JanusGraph utilities
+2. The user loads schema and imports data in backend servers using JanusGraph utilities
+3. The user makes search and update requests in a REST/custom client
+4. The client app sends the REST requests to JanusGraph server
+5. The JanusGraph server interacts with backend to process and return graph data
+
+## Included components
+
+* [Apache Cassandra](http://cassandra.apache.org/): An open source, scalable, high availability database.
+* [JanusGraph](http://janusgraph.org/): A highly scalable graph database optimized for storing and querying large graphs.
+
+## Featured technologies
+* [Databases](https://en.wikipedia.org/wiki/IBM_Information_Management_System#.22Full_Function.22_databases): Repository for storing and managing collections of data.
+* [Java](https://java.com/en/): A secure, object-oriented programming language for creating applications.
+
+# Watch the Video
+
+![Todo]
+
+# Steps
+## Run locally
+1. [Install prerequisites](#1-install-prerequisites)
+2. [Clone the repo](#2-clone-the-repo)
+3. [Generate the graph sample](#3-generate-the-graph-sample)
+4. [Load schema and import data](#4-load-schema-and-import-data)
+5. [Run interactive remote queries](#5-run-interactive-remote-queries)
+
+### 1. Install prerequisites
+> NOTE: These prerequisites can be installed on one server.
+
+Install Cassandra 3.10 on the storage server. Make the following changes in `/etc/cassandra/cassandra.yaml` and restart Cassandra.
+
+```
+start_rpc: true
+rpc_address: 0.0.0.0
+rpc_port: 9160
+broadcast_rpc_address: x.x.x.x (your storage server ip)
+```
+
+Install ElasticSearch 5.3.0 on the index server. Make the following changes in `/etc/elasticsearch/elasticsearch.yml` and restart ElasticSearch.
+
+```
+network.host: x.x.x.x (your index server ip)
+```
+
+Install JanusGraph on the graph server
+* Install java, maven, git
+* Run `git clone https://github.com/JanusGraph/janusgraph.git`
+* Run the following in `janusgraph` folder
+```
+git checkout 4609b6731a01116e96e554140b37ad589f0ae0ca
+mvn clean install -DskipTests=true
+cp conf/janusgraph-cassandra-es.properties conf/janusgraph-cql-es.properties
+vi conf/janusgraph-cql-es.properties
+storage.backend=cql
+storage.hostname=x.x.x.x (your storage server ip)
+index.search.hostname=x.x.x.x (your index server ip)
+```
+
+Install a REST client, such as RESTClient add-on for Firefox, on the client machine
+
+### 2. Clone the repo
+
+Clone the `janusgraph-utils` on the graph server.
+
 ```
 git clone https://github.com/IBM/janusgraph-utils.git
-cd janusgraph-utils
+cd janusgraph-utils/
+mvn package
 ```
 
-Use maven to build this project:
+### 3. Generate the graph sample
 
-`mvn package`
-
-### JanusGraphSchemaImporter
-
-This utility read GraphSON schema document and write to JanusGraph. You can
-run JanusGraphSchemaImporter in two ways:
-- Using groovy script in JanusGraph gremlin console:  
-  After you build the project. You can see the groovy script under `target/groovy` and
-  named `JanusGraphSchemaImporter.groovy`  
-  Usage:  
-  ```
-  gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cassandra-embedded-es.properties')
-  ==>standardjanusgraph[embeddedcassandra:[127.0.0.1]]
-  gremlin> :load JanusGraphSchemaImporter.groovy
-  ......
-  ......
-  ==>true
-  ==>true
-  gremlin> writeGraphSONSchema(graph, 'schema.json')
-  ```  
-  You can find the sample GraphSON schema document under `samples` directory.
-- Using `run.sh` with `loadsch` option to load the schema via JanusGraph Java API.  
-  Usage:  
-  `./run.sh loadsch <janusgraph-config-file> <schema-file>`
-
-#### How to load the groovy script in gremlin console
-Use the following command to load the utility groovy script into gremlin console:
-
+Run the command in `janusgraph-utils` folder to generate data into `/tmp` folder.
 ```
-gremlin> :load <JanusGraphSchemaImporter.groovy>
+./run.sh gencsv csv-conf/twitter-like-w-date.json /tmp
+```
+ Modify generated user file under `/tmp`
+```
+sed -i '2s/.*/1,Indiana Jones/' /tmp/User.csv
+```
+### 4. Load schema and import data
+
+Run the command in `janusgraph-utils` folder to load schema and import data.
+```
+export JANUSGRAPH_HOME=~/janusgraph
+./run.sh import ~/janusgraph/conf/janusgraph-cql-es.properties /tmp /tmp/schema.json /tmp/datamapper.json
 ```
 
-Use the `:load` command and specify the groovy script location to load the groovy script.
-
-#### How to load the groovy scripto into gremlin server
-Modify the gremlin server configuration file `gremlin-server.yaml` under `janusgraph/conf/gremlin-server` directory. Add the groovy script into
-`scriptEngines.gremlin-groovy.scripts`. Its value is an array and contains
-all groovy scripts that would be loaded into gremlin-groovy script engine when
-gremlin server starts. Here is a sample configruation of `gremlin-server.yaml` (partial):
-
-```(YAML)
-scriptEngines: {
-  gremlin-groovy: {
-    imports: [java.lang.Math],
-    staticImports: [java.lang.Math.PI],
-    scripts: [scripts/empty-sample.groovy, scripts/JanusGraphSchemaImporter.groovy]}}
-```
-#### APIs
-Once you load the JanusGraphSchemaImporter.groovy into gremlin console, you can use the following APIs:
-- **JanusGraphSONSchema.parse(file)**:
-  -  file: a string which points to the GraphSON schema document  
-  
-  It parses and returns a schema bean object which contains the whole settings of the GSON schema
-
-- **writeGraphSONSchema(janusgraph, file)**:
-  - janusgraph: a JanusGraph instance
-  - file: a string which points to the GraphSON schema document
-  
-  It parses the GraphSON schema document and write the definitions of properties, vertices and edges into the JanusGraph.
-  
-- **updateCompositeIndexState(janusgraph, indexName, newState)**:
-  - janusgraph: a JanusGraph instance
-  - indexName: the composite index name
-  - newState: the new index state, could be:
-    - SchemaAction.DISABLE_INDEX
-    - SchemaAction.ENABLE_INDEX
-    - SchemaAction.REGISTER_INDEX
-    - SchemaAction.REINDEX
-    - SchemaAction.REMOVE_INDEX
-
-   It changes the index from its original state into new state if the state transition is valid.
-
-#### The GraphSON document
-It contains the defintions of properties, vertices and edges:
+### 5. Run interactive remote queries
+Configure and start JanusGraph server by running the following in `~/janusgraph/conf/gremlin-server` folder.
 
 ```
-{
-    "propertyKeys": [.....],
-    "vertexLabels": [.....],
-    "edgeLabels": [.....],
-    "vertexIndexes": [.....],
-    "edgeIndexes": [.....],
-    "vertexCentricIndexes": [.....]
-}
+cp ~/janusgraph-utils/samples/date-helper.groovy ../../scripts 
+cp ../janusgraph-cql-es.properties janusgraph-cql-es-server.properties
+Add a line to janusgraph-cql-es-server.properties, gremlin.graph=org.janusgraph.core.JanusGraphFactory
+cp gremlin-server.yaml rest-gremlin-server.yaml
+Change rest-gremlin-server.yaml
+host: x.x.x.x (your server ip)
+channelizer: org.apache.tinkerpop.gremlin.server.channel.HttpChannelizer
+graph: conf/gremlin-server/janusgraph-cql-es-server.properties}
+scripts: [scripts/empty-sample.groovy,scripts/date-helper.groovy]}}
+cd ~/janusgraph; ./bin/gremlin-server.sh ./conf/gremlin-server/rest-gremlin-server.yaml
 ```
-
-Each property contains an array of objects. See detailed information for each 
-kind of object below.
-
-**propertyKeys**
-
-It's an array and contains the definition of the properties. Each property is defined in an object with the following format:
+Query and update graph data using REST. Send REST requests using RESTClient in browser with following:
 ```
-{
-    "name": "<propertyName>",
-    "dataType": "<String | Long | Character | Boolean | Byte | Short | Integer | Long | Float | Geoshape | UUID | Date>",
-    "cardinality": "<SINGLE|LIST|SET>"
-}
+Method: POST
+URL: http://x.x.x.x:8182
+Body: {"gremlin":“query_to_run"}
 ```
+Find sample search and insert queries in `samples/twitter-like-queries.txt`
 
-**vertexLabels**
+# Sample output
 
-It's an array and contains the definition of the vertices. Each vertex is
-defined in an object with the following format:
-
-```
-{
-    "name": "<vertex label>",
-    "partition": false|true,    //optional
-    "useStatic": false|true     //optional
-}
-```
-
-**edgeLabels**
-
-It's an array and contains the definition of the edges. Each edge is defined
-in an object with the following format:
-
-```
-{
-    "name": "<edge label>",
-    "multiplicity": "<MULTI | SIMPLE | ONE2MANY | MANY2ONE | ONE2ONE>"
-    "signatures": [ "<property key name>" ]
-    "unidirected" : true|false    //default value is false, means directed
-}
-```
-
-**vertexIndexes**
-
-It's an array and contains the definition of vertex indices. Each vertex index
-is defined in an object with the following format:
-
-```
-{
-    "name": "<index name>",
-    "propertyKeys": ["<property key name>"],
-    "composite": true|false,
-    "unique": true|false,
-    "indexOnly": "<vertex label>"
-}
-```
-
-**edgeIndexes**
-
-It's an array and contains the definition of edge indices. Each edge index
-is defined in an object with the following format:
-
-```
-{
-    "name": "<index name>",
-    "propertyKeys": ["<property key name>"],
-    "composite": true|false,
-    "indexOnly": "<edge label>"
-}
-```
-
-**vertexCentricIndexes**
-
-It's an array and contains the definition of vertex-centric indices. Each
-vertex-centric index is defined in an object with the following format:
-
-```
-{
-    "name": "<index name>",
-    "propertyKeys": ["<property key>"],
-    "edge": "<edge label>",
-    "direction": "BOTH|IN|OUT",
-    "order": "incr|decr"
-}
-```
-
-### Synethic Data Generator
-#### Generate CSV files, schema, and datamapper
-Generate customized CSV for importing to JanusGraph.
-- Usage:  
-  `JanusGraphBench <csv-config-file> <mapper-schema-output-directory>`
-
-Example:  
-      `./run.sh gencsv csv-conf/tiny_config.json /tmp`
-#### CSV config file options:
-- VertexTypes: contains any number of different vertex labels
-  - name: change the name of vertex label
-  - columns: may contain any number of columns(property keys)
-    - [String]: Name of column
-    - dataType: String, Long, Integer,Date
-    - dateRange: default from 1970 to current time in default "dd-MMM-yyyy" format
-      unless specified in the dateFormat
-    - dateFormat: support JAVA SimpleDateFormat patterns. Default: "dd-MMM-yyyy" 	
-    - dataSubType: options are "Name" or "shakespear". This generate some fake data
-    - composit: create composit index or not
-    - row: change number of vertex of the named label
-- EdgeTypes: contains any number of different vertex labels
-  - name: change the first edgelabel name
-  - columns: may contain any number of columns(edge property keys)
-    - [String]: Name of column
-    - dataType: String, Long, Integer, and Date.
-    - dateRange: default from 1970 to current time in default "dd-MMM-yyyy" format
-      unless specified in the date Format
-    - dateFormat: support JAVA SimpleDateFormat patterns. Default: "dd-MMM-yyyy"
-    - composit: true or false
-    - mixedIndex: any String (default should be "search") 
-- relations: Defines how the named edge relations can happen and number of occurrences.
-  - left: the outV of an edge
-  - right: the inV of an edge
-  - supernode: nodes have many edges
-    - vertices: n where n is the first n nodes of left
-    - edges: additional edges are added to each of the n nodes
-    
-### Import CSV file to JanusGraph
-JanusGraphBatchImporter is a tool that imports bulk data into JanusGraph using multiple CSV files for the data and json config files to define the schema and mapping between schema and data. It uses multiple workers in order to achieve full speed of import of the data.
-
-JanusGraphBatchImporter depends on JanusGraph libraries and also commons-csv-1.4.jar
-
-In order to use under Linux:
-- Edit conf/batch_import.properties file to configure the importer
-- Usage:  
-  `run.sh import <janusgraph-config-file> <data-files-directory> <schema.json> <data-mapping.json>`
-  - `<janusgraph-config-file>`: Properties file with the JanuGraph configuration
-  - `<data-files-directory>:` Relative directory where the data files are located
-  - `<schema.json>:` JSON file defining the schema of the graph
-  - `<data-mapping.json>`: mapping file defining the relationship between the CSV/s fields and the graph
-
-- Example:  
-  ```
-  ./run.sh import /root/janusgraph-v0.1.1/conf/janusgraph-cassandra-es.properties \
-      /tmp /tmp/schema.json /tmp/datamapper.json
-  ```
-- Using different JanusGraph lib  
-  ```
-  export JANUSGRAPH_HOME=/path-to-your-janusgraph-home  
-  ./run.sh import /root/path-to-your-janusgraph-home/conf/janusgraph-cassandra-es.properties \
-      /tmp /tmp/schema.json /tmp/datamapper.json
-  ```
+![](doc/source/images/sample_output.png)

--- a/doc/users_guide.md
+++ b/doc/users_guide.md
@@ -1,0 +1,251 @@
+# Utility Tools for JanusGraph 
+
+Provide several utility tools that could be used for Janusgraph, including:
+
+- [JanusGraphSchemaImporter](#janusgraphschemaimporter): a groovy script that imports GraphSON schema document into JanusGraph
+- [Synthetic data generator](#synethic-data-generator): a tools for generating synthetic data in CVS format
+- [Data importor](#import-csv-file-to-janusgraph): a tool to import data into JanusGraph in CVS format
+
+## Download and Build
+
+Download the files from git repo and get into the directory:
+```
+git clone https://github.com/IBM/janusgraph-utils.git
+cd janusgraph-utils
+```
+
+Use maven to build this project:
+
+`mvn package`
+
+### JanusGraphSchemaImporter
+
+This utility read GraphSON schema document and write to JanusGraph. You can
+run JanusGraphSchemaImporter in two ways:
+- Using groovy script in JanusGraph gremlin console:  
+  After you build the project. You can see the groovy script under `target/groovy` and
+  named `JanusGraphSchemaImporter.groovy`  
+  Usage:  
+  ```
+  gremlin> graph = JanusGraphFactory.open('conf/janusgraph-cassandra-embedded-es.properties')
+  ==>standardjanusgraph[embeddedcassandra:[127.0.0.1]]
+  gremlin> :load JanusGraphSchemaImporter.groovy
+  ......
+  ......
+  ==>true
+  ==>true
+  gremlin> writeGraphSONSchema(graph, 'schema.json')
+  ```  
+  You can find the sample GraphSON schema document under `samples` directory.
+- Using `run.sh` with `loadsch` option to load the schema via JanusGraph Java API.  
+  Usage:  
+  `./run.sh loadsch <janusgraph-config-file> <schema-file>`
+
+#### How to load the groovy script in gremlin console
+Use the following command to load the utility groovy script into gremlin console:
+
+```
+gremlin> :load <JanusGraphSchemaImporter.groovy>
+```
+
+Use the `:load` command and specify the groovy script location to load the groovy script.
+
+#### How to load the groovy scripto into gremlin server
+Modify the gremlin server configuration file `gremlin-server.yaml` under `janusgraph/conf/gremlin-server` directory. Add the groovy script into
+`scriptEngines.gremlin-groovy.scripts`. Its value is an array and contains
+all groovy scripts that would be loaded into gremlin-groovy script engine when
+gremlin server starts. Here is a sample configruation of `gremlin-server.yaml` (partial):
+
+```(YAML)
+scriptEngines: {
+  gremlin-groovy: {
+    imports: [java.lang.Math],
+    staticImports: [java.lang.Math.PI],
+    scripts: [scripts/empty-sample.groovy, scripts/JanusGraphSchemaImporter.groovy]}}
+```
+#### APIs
+Once you load the JanusGraphSchemaImporter.groovy into gremlin console, you can use the following APIs:
+- **JanusGraphSONSchema.parse(file)**:
+  -  file: a string which points to the GraphSON schema document  
+  
+  It parses and returns a schema bean object which contains the whole settings of the GSON schema
+
+- **writeGraphSONSchema(janusgraph, file)**:
+  - janusgraph: a JanusGraph instance
+  - file: a string which points to the GraphSON schema document
+  
+  It parses the GraphSON schema document and write the definitions of properties, vertices and edges into the JanusGraph.
+  
+- **updateCompositeIndexState(janusgraph, indexName, newState)**:
+  - janusgraph: a JanusGraph instance
+  - indexName: the composite index name
+  - newState: the new index state, could be:
+    - SchemaAction.DISABLE_INDEX
+    - SchemaAction.ENABLE_INDEX
+    - SchemaAction.REGISTER_INDEX
+    - SchemaAction.REINDEX
+    - SchemaAction.REMOVE_INDEX
+
+   It changes the index from its original state into new state if the state transition is valid.
+
+#### The GraphSON document
+It contains the defintions of properties, vertices and edges:
+
+```
+{
+    "propertyKeys": [.....],
+    "vertexLabels": [.....],
+    "edgeLabels": [.....],
+    "vertexIndexes": [.....],
+    "edgeIndexes": [.....],
+    "vertexCentricIndexes": [.....]
+}
+```
+
+Each property contains an array of objects. See detailed information for each 
+kind of object below.
+
+**propertyKeys**
+
+It's an array and contains the definition of the properties. Each property is defined in an object with the following format:
+```
+{
+    "name": "<propertyName>",
+    "dataType": "<String | Long | Character | Boolean | Byte | Short | Integer | Long | Float | Geoshape | UUID | Date>",
+    "cardinality": "<SINGLE|LIST|SET>"
+}
+```
+
+**vertexLabels**
+
+It's an array and contains the definition of the vertices. Each vertex is
+defined in an object with the following format:
+
+```
+{
+    "name": "<vertex label>",
+    "partition": false|true,    //optional
+    "useStatic": false|true     //optional
+}
+```
+
+**edgeLabels**
+
+It's an array and contains the definition of the edges. Each edge is defined
+in an object with the following format:
+
+```
+{
+    "name": "<edge label>",
+    "multiplicity": "<MULTI | SIMPLE | ONE2MANY | MANY2ONE | ONE2ONE>"
+    "signatures": [ "<property key name>" ]
+    "unidirected" : true|false    //default value is false, means directed
+}
+```
+
+**vertexIndexes**
+
+It's an array and contains the definition of vertex indices. Each vertex index
+is defined in an object with the following format:
+
+```
+{
+    "name": "<index name>",
+    "propertyKeys": ["<property key name>"],
+    "composite": true|false,
+    "unique": true|false,
+    "indexOnly": "<vertex label>"
+}
+```
+
+**edgeIndexes**
+
+It's an array and contains the definition of edge indices. Each edge index
+is defined in an object with the following format:
+
+```
+{
+    "name": "<index name>",
+    "propertyKeys": ["<property key name>"],
+    "composite": true|false,
+    "indexOnly": "<edge label>"
+}
+```
+
+**vertexCentricIndexes**
+
+It's an array and contains the definition of vertex-centric indices. Each
+vertex-centric index is defined in an object with the following format:
+
+```
+{
+    "name": "<index name>",
+    "propertyKeys": ["<property key>"],
+    "edge": "<edge label>",
+    "direction": "BOTH|IN|OUT",
+    "order": "incr|decr"
+}
+```
+
+### Synethic Data Generator
+#### Generate CSV files, schema, and datamapper
+Generate customized CSV for importing to JanusGraph.
+- Usage:  
+  `JanusGraphBench <csv-config-file> <mapper-schema-output-directory>`
+
+Example:  
+      `./run.sh gencsv csv-conf/tiny_config.json /tmp`
+#### CSV config file options:
+- VertexTypes: contains any number of different vertex labels
+  - name: change the name of vertex label
+  - columns: may contain any number of columns(property keys)
+    - [String]: Name of column
+    - dataType: String, Long, Integer,Date
+    - dateRange: default from 1970 to current time in default "dd-MMM-yyyy" format
+      unless specified in the dateFormat
+    - dateFormat: support JAVA SimpleDateFormat patterns. Default: "dd-MMM-yyyy" 	
+    - dataSubType: options are "Name" or "shakespear". This generate some fake data
+    - composit: create composit index or not
+    - row: change number of vertex of the named label
+- EdgeTypes: contains any number of different vertex labels
+  - name: change the first edgelabel name
+  - columns: may contain any number of columns(edge property keys)
+    - [String]: Name of column
+    - dataType: String, Long, Integer, and Date.
+    - dateRange: default from 1970 to current time in default "dd-MMM-yyyy" format
+      unless specified in the date Format
+    - dateFormat: support JAVA SimpleDateFormat patterns. Default: "dd-MMM-yyyy"
+    - composit: true or false
+    - mixedIndex: any String (default should be "search") 
+- relations: Defines how the named edge relations can happen and number of occurrences.
+  - left: the outV of an edge
+  - right: the inV of an edge
+  - supernode: nodes have many edges
+    - vertices: n where n is the first n nodes of left
+    - edges: additional edges are added to each of the n nodes
+    
+### Import CSV file to JanusGraph
+JanusGraphBatchImporter is a tool that imports bulk data into JanusGraph using multiple CSV files for the data and json config files to define the schema and mapping between schema and data. It uses multiple workers in order to achieve full speed of import of the data.
+
+JanusGraphBatchImporter depends on JanusGraph libraries and also commons-csv-1.4.jar
+
+In order to use under Linux:
+- Edit conf/batch_import.properties file to configure the importer
+- Usage:  
+  `run.sh import <janusgraph-config-file> <data-files-directory> <schema.json> <data-mapping.json>`
+  - `<janusgraph-config-file>`: Properties file with the JanuGraph configuration
+  - `<data-files-directory>:` Relative directory where the data files are located
+  - `<schema.json>:` JSON file defining the schema of the graph
+  - `<data-mapping.json>`: mapping file defining the relationship between the CSV/s fields and the graph
+
+- Example:  
+  ```
+  ./run.sh import /root/janusgraph-v0.1.1/conf/janusgraph-cassandra-es.properties \
+      /tmp /tmp/schema.json /tmp/datamapper.json
+  ```
+- Using different JanusGraph lib  
+  ```
+  export JANUSGRAPH_HOME=/path-to-your-janusgraph-home  
+  ./run.sh import /root/path-to-your-janusgraph-home/conf/janusgraph-cassandra-es.properties \
+      /tmp /tmp/schema.json /tmp/datamapper.json
+  ```


### PR DESCRIPTION
Replace README.md with the recommended journey stile. Move
the old README.md to be doc/users_guide.md.

Signed-off-by: Chin Huang <chhuang@us.ibm.com>