### PR TITLE
Escape dquotes so sample works in RESTClient. Fix typos.

### DIFF
--- a/samples/twitter-like-queries.txt
+++ b/samples/twitter-like-queries.txt
@@ -1,4 +1,4 @@
-Note: The following queries work assuming the super user (with node_id=1 in User.csv) name is 'Indiana Jones' and date-help.groovy is loaded in JanusGraph console or server. If the super user name is different, simple replace it in the queries.
+Note: The following queries work assuming the super user (with node_id=1 in User.csv) name is 'Indiana Jones' and date-helper.groovy is loaded in JanusGraph console or server. If the super user name is different, simply replace it in the queries.
 
 1. Who follows ‘Indiana Jones’?
 g.V().has('name', 'Indiana Jones').in('Follows').values('name')
@@ -25,7 +25,7 @@ g.V().has('name', 'Indiana Jones').in('Follows').as('a').out('Retweets').in('Twe
 g.V().has('name', 'Indiana Jones').in('Follows').out('Retweets').as('a').in('Tweets').has('name', 'Indiana Jones').select('a').by('text').dedup()
 
 9. Find Indiana Jones' followers who retweeted his tweets and the retweeted tweets
-g.V().has('name', 'Indiana Jones').in('Follows').has('name',not(within('Indiana Jones'))).as('follower').out('Retweets').as('retweet').in('Tweets').has('name', 'Indiana Jones').sideEffect{println "${it.path().get('follower').value('name')} retweeted ===> ${it.path().get('retweet').value('text')}" }
+g.V().has('name', 'Indiana Jones').in('Follows').has('name',not(within('Indiana Jones'))).as('follower').out('Retweets').as('retweet').in('Tweets').has('name', 'Indiana Jones').sideEffect{println \"${it.path().get('follower').value('name')} retweeted ===> ${it.path().get('retweet').value('text')}\" }
 
 10.Add a new user
 g.addV('User').property('name','John Doe')
@@ -33,7 +33,7 @@ g.addV('User').property('name','John Doe')
 11. Add a message
 g.addV('Tweet').property('text','Hello, Friday!')
 
-12. Johe Doe tweets a message
+12. John Doe tweets a message
 g.V().has('text', 'Hello, Friday!').as('a').V().has('name', 'John Doe').addE('Tweets').to('a').property('Date',createDate(2017,8,18))
 
 13. Make John Doe follow Indiana Jones


### PR DESCRIPTION
* Example 9 doesn't work in a REST client JSON because it has
  double quotes that need escaping for the JSON. Should we escape
  them like this or just document it?

* Fix a couple typos in samples/twitter-like-queries.txt