### PR TITLE
Use queue to store Worker

### DIFF
--- a/src/main/java/com/ibm/janusgraph/utils/importer/dataloader/DataFileLoader.java
+++ b/src/main/java/com/ibm/janusgraph/utils/importer/dataloader/DataFileLoader.java
@@ -57,6 +57,8 @@ public class DataFileLoader {
             Worker worker = constructor.newInstance(sub.iterator(), propertiesMap, graph);
             workers.submit(worker);
         }
+        //main thread would wait here
+        workers.wait4Finish();
     }
 
     public void loadFile(String fileName, Map<String, Object> propertiesMap, WorkerPool workers) throws Exception {

--- a/src/main/java/com/ibm/janusgraph/utils/importer/edge/EdgeLoaderWorker.java
+++ b/src/main/java/com/ibm/janusgraph/utils/importer/edge/EdgeLoaderWorker.java
@@ -33,6 +33,7 @@ import com.ibm.janusgraph.utils.importer.util.BatchHelper;
 import com.ibm.janusgraph.utils.importer.util.Config;
 import com.ibm.janusgraph.utils.importer.util.Constants;
 import com.ibm.janusgraph.utils.importer.util.Worker;
+import com.ibm.janusgraph.utils.importer.util.WorkerListener;
 
 public class EdgeLoaderWorker extends Worker {
     private final UUID myID = UUID.randomUUID();
@@ -164,5 +165,7 @@ public class EdgeLoaderWorker extends Worker {
 
         graphTransaction = null;
         log.info("Finished thread " + myID);
+
+        notifyListener(WorkerListener.State.Done);
     }
 }

--- a/src/main/java/com/ibm/janusgraph/utils/importer/util/Worker.java
+++ b/src/main/java/com/ibm/janusgraph/utils/importer/util/Worker.java
@@ -17,11 +17,15 @@ package com.ibm.janusgraph.utils.importer.util;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.janusgraph.core.JanusGraph;
 
+
 public abstract class Worker implements Runnable {
     private final Iterator<Map<String, String>> records;
+    private List<WorkerListener> listeners = new LinkedList<WorkerListener>();
     private final JanusGraph graph;
     private final Map<String, Object> propertiesMap;
 
@@ -44,4 +48,17 @@ public abstract class Worker implements Runnable {
         return propertiesMap;
     }
 
+    public void addListener(WorkerListener listener) {
+        listeners.add(listener);
+    }
+
+    /**
+     * Notify the state change to all listeners
+     * @param state new state
+     */
+    public void notifyListener(WorkerListener.State state) {
+        listeners.forEach(listener -> {
+            listener.notify(this, state);
+        });
+    }
 }

--- a/src/main/java/com/ibm/janusgraph/utils/importer/util/WorkerListener.java
+++ b/src/main/java/com/ibm/janusgraph/utils/importer/util/WorkerListener.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ *   Copyright 2017 IBM Corp. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *******************************************************************************/
+package com.ibm.janusgraph.utils.importer.util;
+
+/**
+ * Receive worker state change event
+ */
+public interface WorkerListener {
+    /**
+     * Worker state
+     * - Running: perform the work
+     * - Done: finish the work
+     */
+    public enum State {
+        Running,
+        Done
+    }
+
+    /**
+     * Notify state change
+     * @param state
+     */
+    public void notify(Worker worker, State state);
+}

--- a/src/main/java/com/ibm/janusgraph/utils/importer/util/WorkerPool.java
+++ b/src/main/java/com/ibm/janusgraph/utils/importer/util/WorkerPool.java
@@ -15,38 +15,43 @@
  *******************************************************************************/
 package com.ibm.janusgraph.utils.importer.util;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
-public class WorkerPool implements AutoCloseable {
+public class WorkerPool implements AutoCloseable, WorkerListener {
     private static ExecutorService processor;
-    private List<Future<?>> futures = new ArrayList<Future<?>>();
-
+    private static final int sQueueCap = 50;
+    private LinkedBlockingQueue<Worker> queue = new LinkedBlockingQueue<Worker>(sQueueCap);
+    private AtomicInteger workerCounter = new AtomicInteger(0);
     private final long shutdownWaitMS = 10000;
-//    private int maxWorkers;
+    private Semaphore finished = new Semaphore(1);
     private int numThreads;
 
     public WorkerPool(int numThreads, int maxWorkers) {
         this.numThreads = numThreads;
-//        this.maxWorkers = maxWorkers;
         processor = Executors.newFixedThreadPool(numThreads);
+        finished.acquireUninterruptibly();
     }
 
-    public void submit(Runnable runnable) throws Exception {
-        Future<?> future = processor.submit(runnable);
-        futures.add(future);
-        while (futures.size() > numThreads) {
-            for (int i = 0; i < futures.size(); i++) {
-                Future<?> f = futures.get(i);
-                if (f.isDone()) {
-                    futures.remove(i);
-                }
+    public void submit(Worker worker) {
+        worker.addListener(this);
+        if (workerCounter.get() <= numThreads) {
+            workerCounter.incrementAndGet();
+            processor.submit(worker);
+        } else {
+            // adding the worker into queue is better then
+            // using semaphore to block the feeding and wait
+            // for some worker to finish. This creates
+            // some sort of buffer effect.
+            try {
+                queue.put(worker);
+            } catch (InterruptedException e) {
+                e.printStackTrace(System.out);
             }
-            Thread.sleep(1000);
         }
     }
 
@@ -60,8 +65,34 @@ public class WorkerPool implements AutoCloseable {
         }
     }
 
+    /**
+     * Pause the current thread and wait until all
+     * workers finish their jobs.
+     */
+    public void wait4Finish() {
+        finished.acquireUninterruptibly();
+    }
+
     @Override
     public void close() throws Exception {
         closeProcessor();
+    }
+
+    @Override
+    public void notify(Worker worker, WorkerListener.State state) {
+        switch (state) {
+        case Running:
+            break;
+        case Done:
+            Worker queueItem = queue.poll();
+            if (queueItem != null) {
+                processor.submit(queueItem);
+            } else if (workerCounter.decrementAndGet() == 0){
+                finished.release();
+            }
+            break;
+        default:
+            break;
+        }
     }
 }

--- a/src/main/java/com/ibm/janusgraph/utils/importer/vertex/VertexLoaderWorker.java
+++ b/src/main/java/com/ibm/janusgraph/utils/importer/vertex/VertexLoaderWorker.java
@@ -30,6 +30,7 @@ import com.ibm.janusgraph.utils.importer.util.BatchHelper;
 import com.ibm.janusgraph.utils.importer.util.Config;
 import com.ibm.janusgraph.utils.importer.util.Constants;
 import com.ibm.janusgraph.utils.importer.util.Worker;
+import com.ibm.janusgraph.utils.importer.util.WorkerListener;
 
 public class VertexLoaderWorker extends Worker {
     private final UUID myID = UUID.randomUUID();
@@ -130,6 +131,8 @@ public class VertexLoaderWorker extends Worker {
         graphTransaction.close();
 
         log.info("Finished thread " + myID);
+
+        notifyListener(WorkerListener.State.Done);
     }
 
 }


### PR DESCRIPTION
Instead of keep scanning through the whole worker list,
use LinkedBlockingQueue to store the worker. This also
provide the data  buffering, which loads the csv
data into memory and wait for the available thread to
run the job.

Signed-off-by: Yihong Wang <yh.wang@ibm.com>