### PR TITLE
Allow custom datasubtype as list of string to be specified

### DIFF
--- a/src/main/java/com/ibm/janusgraph/utils/generator/CSVGenerator.java
+++ b/src/main/java/com/ibm/janusgraph/utils/generator/CSVGenerator.java
@@ -109,6 +109,12 @@ public class CSVGenerator {
                     roles.put(3, () -> rec.add(faker.shakespeare().kingRichardIIIQuote()));
                     roles.put(4, () -> rec.add(faker.shakespeare().romeoAndJulietQuote()));
                     roles.get(RandomUtils.nextInt(1,5)).run();
+                }else if (value.dataSubType != null && value.dataSubType.toLowerCase().equals("custom") && value.options != null) {
+                    Faker faker = new Faker();
+                    rec.add(faker.options().option(value.options));
+                }else if (value.dataSubType != null && value.dataSubType.toLowerCase().equals("company")) {
+                    Faker faker = new Faker();
+                    rec.add(faker.company().name());
                 }else {
                     rec.add(RandomStringUtils.randomAlphabetic(10));
                 }

--- a/src/main/java/com/ibm/janusgraph/utils/generator/bean/ColumnBean.java
+++ b/src/main/java/com/ibm/janusgraph/utils/generator/bean/ColumnBean.java
@@ -28,4 +28,5 @@ public class ColumnBean {
     public String dataSubType; //to support sub categories of certain dataTypes
     public Map<String, String> dateRange = null;
     public String dateFormat = null;
+    public String[] options;
 }


### PR DESCRIPTION
Allow random selection from a defined "options" list by specifying "custom" dataSubType in a csv-config json
- For example: "bodytype": {"dataType":"String", "dataSubType":"custom", "options":["sedan","coupe","suv","minivan","wagon"]}
Add an ability to randomly generate company names in a csv-config json.
- For example: "name": {"dataType":"String", "dataSubType":"company", "composit":true}