### PR TITLE
Update VertexLoaderWorker.java :: acceptRecord

### DIFF
--- a/src/main/java/com/ibm/janusgraph/utils/importer/vertex/VertexLoaderWorker.java
+++ b/src/main/java/com/ibm/janusgraph/utils/importer/vertex/VertexLoaderWorker.java
@@ -71,39 +71,38 @@ public class VertexLoaderWorker extends Worker {
             vertexLabel = record.get(vertexLabelFieldName);
         }
         JanusGraphVertex v = graphTransaction.addVertex(vertexLabel);
+		// Removes the vertex in catch block if uniqueness constraint fails for a key and value 
+        try {
+        	// set the properties of the vertex
+        	for (String column : record.keySet()) {
+        		String value = record.get(column);
+        		// If value="" or it is a vertex label then skip it
+        		if (value == null || value.length() == 0 || column.equals(vertexLabelFieldName))
+        			continue;
 
-        // set the properties of the vertex
-        for (String column : record.keySet()) {
-            String value = record.get(column);
-            // If value="" or it is a vertex label then skip it
-            if (value == null || value.length() == 0 || column.equals(vertexLabelFieldName))
-                continue;
+        		String propName = (String) getPropertiesMap().get(column);
+        		if (propName == null) {
+        			// log.info("Thread " + myID + ".Cannot find property name for
+        			// column " + column
+        			// + " in the properties map. Using the column name as
+        			// default.");
+        			continue;
+        			// propName = column;
+        		}
 
-            String propName = (String) getPropertiesMap().get(column);
-            if (propName == null) {
-                // log.info("Thread " + myID + ".Cannot find property name for
-                // column " + column
-                // + " in the properties map. Using the column name as
-                // default.");
-                continue;
-                // propName = column;
-            }
-
-            // Update property only if it does not exist already
-            // Removes the vertex in catch block if uniqueness constraint fails for a key and value 
-            try {
-            	if (!v.properties(propName).hasNext()) {
-            		// TODO Convert properties between data types. e.g. Date
-            		Object convertedValue = BatchHelper.convertPropertyValue(value,    							
-            				graphTransaction.getPropertyKey(propName).dataType());
-            		v.property(propName, convertedValue);
-            	}
-            } catch (Exception error) {
-            	log.error("Error in update property::acceptRecord:: Vertex:: "+vertexLabel+" :: "+error);
-            	v.remove();
-            	log.info("acceptRecord::Vertex Removed");
-            	return;
-            }
+        		// Update property only if it does not exist already
+        		if (!v.properties(propName).hasNext()) {
+        			// TODO Convert properties between data types. e.g. Date
+        			Object convertedValue = BatchHelper.convertPropertyValue(value,    							
+        					graphTransaction.getPropertyKey(propName).dataType());
+        			v.property(propName, convertedValue);
+        		}
+        	} 
+        } catch (Exception error) {
+        	log.error("Error in acceptRecord:: Vertex:: "+vertexLabel+" :: "+error);
+        	v.remove();
+        	log.info("acceptRecord::Vertex Removed");
+        	return;
         }
 
         if (currentRecord % COMMIT_COUNT == 0) {

--- a/src/main/java/com/ibm/janusgraph/utils/importer/vertex/VertexLoaderWorker.java
+++ b/src/main/java/com/ibm/janusgraph/utils/importer/vertex/VertexLoaderWorker.java
@@ -90,11 +90,19 @@ public class VertexLoaderWorker extends Worker {
             }
 
             // Update property only if it does not exist already
-            if (!v.properties(propName).hasNext()) {
-                // TODO Convert properties between data types. e.g. Date
-                Object convertedValue = BatchHelper.convertPropertyValue(value,
-                        graphTransaction.getPropertyKey(propName).dataType());
-                v.property(propName, convertedValue);
+            // Removes the vertex in catch block if uniqueness constraint fails for a key and value 
+            try {
+            	if (!v.properties(propName).hasNext()) {
+            		// TODO Convert properties between data types. e.g. Date
+            		Object convertedValue = BatchHelper.convertPropertyValue(value,    							
+            				graphTransaction.getPropertyKey(propName).dataType());
+            		v.property(propName, convertedValue);
+            	}
+            } catch (Exception error) {
+            	log.error("Error in update property::acceptRecord:: Vertex:: "+vertexLabel+" :: "+error);
+            	v.remove();
+            	log.info("acceptRecord::Vertex Removed");
+            	return;
             }
         }
 


### PR DESCRIPTION
This change deletes a vertex if it fails when we input the data. It logs the error what the defect was and then removes it.
The complete batch does not fail because of one vertex failing due to unique property being added again.
```ERROR VertexLoaderWorker:102 - Error in update property::acceptRecord:: Vertex:: party :: org.janusgraph.core.SchemaViolationException: Adding this property for key [node_id] and value [16730] violates a uniqueness constraint [node_id_comp]```
```INFO VertexLoaderWorker:104 - acceptRecord::Vertex Removed```

Github issue: #74 

BDD Test:
- GIVEN user has files to upload and knows how to run this utility.
- WHEN JanusGraph DB is empty (no data).
- THEN run this utility script to add data to JanusGraph.
- THEN run gremlin console and check the count of the vertex.
- THEN run the utility script again for the same set of data to add in JanusGraph.
- WHEN above step is executed, check utility logs to see vertex is removed.
- THEN run gremlin console again and check the vertex count. It should be same as before (if no new
   data was added to the files)